### PR TITLE
Add text normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: clean-test test
+
+clean-test: ## remove test artifacts
+	rm -fr .pytest_cache
+
+test: clean-test ## Run tests using pytest
+	poetry run pytest

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Get wrecked.
 
 *TODO: add MacOS instructions*
 
+
+## Testing the code
+
+`make test`
+
+
 ## Architecture
 
 ![image](https://user-images.githubusercontent.com/5240492/68536204-082ada00-0304-11ea-979c-052883fa2484.png)

--- a/corpus_explorer/preprocessing.py
+++ b/corpus_explorer/preprocessing.py
@@ -1,0 +1,44 @@
+"""This is where we put all of the code to preprocess and shape a text collection
+so that it can be used as input to a topic model learner.
+"""
+
+import re
+from typing import Iterable
+
+
+PUNCT_RE = r'[!"#$%&\'()*+,./:;<=>?@\^_`{|}~]'
+
+
+def normalize_text(text: str) -> str:
+    """Take raw text and apply several normalization steps to it.
+
+    Specifically we perform:
+        - lowercasing
+        - numbers removal
+        - punctuation removal
+
+    Notes
+    -----
+    This function is currently just a minimal example. We might want to consider
+    other normalization steps, such as:
+        - stopword removal
+        - lemmatization
+        - stemming
+
+    Parameters
+    ----------
+    text:
+        Input text in its raw form.
+
+    Returns
+    -------
+    Normalized text.
+
+    """
+    text = text.lower()
+    text = re.sub(r'\d+', '', text)
+    text = re.sub(PUNCT_RE, '', text)
+    text = re.sub(r'\s\s+', ' ', text)  # Handle excess whitespace
+    text = text.strip()  # No whitespace at start and end of string
+
+    return text

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,6 +8,22 @@ python-versions = "*"
 version = "0.1.0"
 
 [[package]]
+category = "main"
+description = "Atomic file writes."
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.3.0"
+
+[[package]]
+category = "main"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[[package]]
 category = "dev"
 description = "Specifications for callback functions passed in to an API"
 name = "backcall"
@@ -73,7 +89,7 @@ python-versions = "*"
 version = "3.0.4"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
@@ -118,6 +134,18 @@ name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.8"
+
+[[package]]
+category = "main"
+description = "Read metadata from Python packages"
+marker = "python_version < \"3.8\""
+name = "importlib-metadata"
+optional = false
+python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
+version = "0.23"
+
+[package.dependencies]
+zipp = ">=0.5"
 
 [[package]]
 category = "dev"
@@ -169,11 +197,31 @@ version = "0.9.4"
 
 [[package]]
 category = "main"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+python-versions = ">=3.4"
+version = "7.2.0"
+
+[[package]]
+category = "main"
 description = "NumPy is the fundamental package for array computing with Python."
 name = "numpy"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.16.1"
+
+[[package]]
+category = "main"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.2"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
 
 [[package]]
 category = "main"
@@ -217,6 +265,19 @@ python-versions = "*"
 version = "0.7.5"
 
 [[package]]
+category = "main"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.0"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[[package]]
 category = "dev"
 description = "Library for building powerful interactive command lines in Python"
 name = "prompt-toolkit"
@@ -239,6 +300,14 @@ version = "0.6.0"
 
 [[package]]
 category = "main"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.0"
+
+[[package]]
+category = "main"
 description = "Python library for Apache Arrow"
 name = "pyarrow"
 optional = false
@@ -256,6 +325,36 @@ name = "pygments"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.4.2"
+
+[[package]]
+category = "main"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.4"
+
+[[package]]
+category = "main"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.2.2"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [[package]]
 category = "main"
@@ -355,19 +454,33 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.25.6"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
 optional = false
 python-versions = "*"
 version = "0.1.7"
 
+[[package]]
+category = "main"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+marker = "python_version < \"3.8\""
+name = "zipp"
+optional = false
+python-versions = ">=2.7"
+version = "0.6.0"
+
+[package.dependencies]
+more-itertools = "*"
+
 [metadata]
-content-hash = "dec6ecea243fa4eeca23b7a7cb676d8e263217492cf6ae84d219b510886cabb0"
+content-hash = "7a4f1a22b4002461952448e78b922b58449b159359a14a97eb9237c22504b52b"
 python-versions = "^3.7"
 
 [metadata.hashes]
 appnope = ["5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0", "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"]
+atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
+attrs = ["08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c", "f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"]
 backcall = ["38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4", "bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"]
 boto = ["147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8", "ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"]
 boto3 = ["aa40df7958bb274fad45ce6cc9ae1c77aac3b4cf33c34684646b42583a52d7e0", "cb8f2531c22a4cf7847f62a9e23c2611300b6fdbcad577f67a9b56b686f78dd5"]
@@ -379,19 +492,26 @@ decorator = ["54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
 docutils = ["6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0", "9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827", "a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"]
 gensim = ["03edf191f1ada39db767fd593f8f9cee20e25dd17f5df9b8c71a2355113f7e7e", "091db4e1489399192214dd2466e7c5b4f9cd82c2ba8dfa468a6572cde11c8558", "10d0a01a541aa9810add46fe2ccb043a86d99f5075f8dc35466f65949adcb64c", "11c01f38a77579b4fda635b92f1231b2986d9fefff44af401c2d106901b9342a", "1a302a0829eaa023fa6e91e3b489e5b6173127124f2bfbdfa4118b75bd402264", "1b747baf65b51e101db5b4b8eb84ac2c400ab81c3fb0758ff5f879693e936ce3", "1cfd541f4a8651d5d24f61b35a263573bb3464f1d72d12366c4ab15931c81fad", "267983deeb6969a43f7366a188c4f5f2942a49271b7dbdfc07066707fb2029e2", "33277fc0a8d7b0c7ce70fcc74bb82ad39f944c009b334856c6e86bf552b1dfdc", "36518200175c708e762f5763f34b1e5a6b64e7844f2c172afd480231361192fd", "3cae31d081a1770eda226c63290da198c0fa55a4b680ed18eb5360a4be9bd5da", "3dba0af2c02bbcf30496b2fab7378e4190cad32a6a1145eec0f2cb5a40189c73", "458c2dea186e7e35fa417b13060c4c5ce63e90c36240c745574a95c2b02c425b", "498bc173df0cebb430e01d9860d8cb9a1d4724537da3b3b1b6ec371ddd86794e", "49cb7fe8edc70aef22cdc884d7b8b9b22f892ae5918e2ca8e21bd9c13df02383", "4e5344a07e6646198669befb3f6d3d25209693a904863293da2b0233c5526686", "56fc56f1b8044f33c29ab3f5416d05a1655223a7654cc0887e4e0a17f50e6006", "58f28f6dd25cb4f83ace8b6be1e132d56acfd60b823241e84bb8cba2e9676a39", "6c7065de589edd53cd42f4e5bbae8a821d285c75f12412ee0e32c972f14672c1", "734c8fcd65068f06c1da37beeec7b22a9380faa63a307a99b0bb109560e05e47", "88ad391dff5117a3521538b77e724013dc0c751d0c96bd5e8026bcf759e2afe1", "a4d9806496823c5e4f787118b87e55f61360ece0ea0fbebef7eb0782492077d9", "ace82a26c9d4663fbe55c2d84ee168edd0e9e23062a0961ff99575615ca4603a", "afca1f0081b5e1ce3f07d7ac540196c1af81b9d0513fbd8c4744cc7910922e09", "b08c526ce5dabceb042499c7711e229fb3d2874f69a83dbcab77a35bedac8552", "ba19d8021554c773420321cc0b1ad5ed1f0cd5d14c08a24631263f23d6e8c14e", "bd0e40149a6f07961123f8770b68050366b6772f38521c75a9d0b03242cb9fde", "d3b3cb01e4e997731c41944ffbfce2af67585c6a60fd4fc4a02909dff77021aa", "d9f13b7f0c425b632f18b0b7c87551a0e0d87695506e63153b442e137a4a69fd", "db3b8cfc03e9b7e4c93ea2221cb82d9719fcc3cd16201191f45f12e3c9b0f206", "ef51a5aada90ce0f8f13be750e8d8460bd33e2793c2e74bb453fb1ce7b7ba79d"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
+importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26", "d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"]
 ipython = ["dfd303b270b7b5232b3d08bd30ec6fd685d8a58cabd54055e3d69d8f029f7280", "ed7ebe1cba899c1c3ccad6f7f1c2d2369464cc77dba8eebc65e2043e19cda995"]
 ipython-genutils = ["72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8", "eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"]
 jedi = ["786b6c3d80e2f06fd77162a07fed81b8baa22dde5d62896a790a331d6ac21a27", "ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e"]
 jmespath = ["3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6", "bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"]
+more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
 numpy = ["0cdbbaa30ae69281b18dd995d3079c4e552ad6d5426977f66b9a2a95f11f552a", "2b0cca1049bd39d1879fa4d598624cafe82d35529c72de1b3d528d68031cdd95", "31d3fe5b673e99d33d70cfee2ea8fe8dccd60f265c3ed990873a88647e3dd288", "34dd4922aab246c39bf5df03ca653d6265e65971deca6784c956bf356bca6197", "384e2dfa03da7c8d54f8f934f61b6a5e4e1ebb56a65b287567629d6c14578003", "392e2ea22b41a22c0289a88053204b616181288162ba78e6823e1760309d5277", "4341a39fc085f31a583be505eabf00e17c619b469fef78dc7e8241385bfddaa4", "45080f065dcaa573ebecbfe13cdd86e8c0a68c4e999aa06bd365374ea7137706", "485cb1eb4c9962f4cd042fed9424482ec1d83fee5dc2ef3f2552ac47852cb259", "575cefd28d3e0da85b0864506ae26b06483ee4a906e308be5a7ad11083f9d757", "62784b35df7de7ca4d0d81c5b6af5983f48c5cdef32fc3635b445674e56e3266", "69c152f7c11bf3b4fc11bc4cc62eb0334371c0db6844ebace43b7c815b602805", "6ccfdcefd287f252cf1ea7a3f1656070da330c4a5658e43ad223269165cdf977", "7298fbd73c0b3eff1d53dc9b9bdb7add8797bb55eeee38c8ccd7906755ba28af", "79463d918d1bf3aeb9186e3df17ddb0baca443f41371df422f99ee94f4f2bbfe", "8bbee788d82c0ac656536de70e817af09b7694f5326b0ef08e5c1014fcb96bb3", "a863957192855c4c57f60a75a1ac06ce5362ad18506d362dd807e194b4baf3ce", "ae602ba425fb2b074e16d125cdce4f0194903da935b2e7fe284ebecca6d92e76", "b13faa258b20fa66d29011f99fdf498641ca74a0a6d9266bc27d83c70fea4a6a", "c2c39d69266621dd7464e2bb740d6eb5abc64ddc339cc97aa669f3bb4d75c103", "e9c88f173d31909d881a60f08a8494e63f1aff2a4052476b24d4f50e82c47e24", "f1a29267ac29fff0913de0f11f3a9edfcd3f39595f467026c29376fad243ebe3", "f69dde0c5a137d887676a8129373e44366055cf19d1b434e853310c7a1e68f93"]
+packaging = ["28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47", "d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"]
 pandas = ["00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d", "22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e", "255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b", "26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7", "33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2", "4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9", "52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4", "61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0", "6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71", "7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3", "78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b", "8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f", "975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17", "9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d", "adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a", "bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf", "df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133", "e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7", "ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"]
 parso = ["63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc", "666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"]
 pexpect = ["2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1", "9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"]
 pickleshare = ["87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", "9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"]
+pluggy = ["0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6", "fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"]
 prompt-toolkit = ["46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4", "e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31", "f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db"]
 ptyprocess = ["923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0", "d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"]
+py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
 pyarrow = ["030d67418b129eb14a1c1f1af06b1a48c8074005d704789725ea6f5addaf3b26", "13f921560bac5ad46b17513696e38fede0c0e92ba750c7b350c0b231815bb706", "14dbc00edd14133c15d62c8d6c566a82a7497b077f253fc0c2dad62c7f85beaa", "17cda6ba594acf5a72058dd2e5ca2586fe8781fc8d20bd750a3b7c66c8b274b2", "1f3934b2add6839844443c1ac0eba64e14b2b8253563574d45d6831851b11d47", "2964a3fe09fbe704160734d00bef7b023699dc6a603dc8eb889b095effc464db", "364806e26769ca20a79b1ead301c7ce28fd0534eb6d411d441053288d7e45817", "41cf5ed34012c43b4ceeeeb2534e3454c77e852bc9175d2e506b45bad132db49", "4f0276e258065c82dcb7edfc28c343ccad15da02b25e57e7c60ceb80e3f7268b", "4fa03d2bc725e948f361a8ce7de271e39d90130ee3a3375793ac241b452c5bfa", "5a07222b80ae36219c558cb8875e7e346f779d0862ae277c68899db879cf5cd7", "5f6026673ceaa037cb41fbe86ce7ea6483cfdc91e51dea929fbbf81883a73d96", "7ad074690ba38313067bf3bbda1258966d38e2037c035d08b9ffe3cce07747a5", "87a2324a6e41faff3a482dbfc54a1f51bbf2d7da39ee728ec73869e2ef892a97", "b508b860486f75bcfeab72b98b4d8caa3a1517e5b7a9b3adcd5bc4539bff8a1a", "bc7200f7a97aea7301f61cd616b33069d1098e6d9178db6a34ccd43ea9223f53", "c70f7d0032be960d8dbd32661a9de062af184f411400ea2f4a13883ca11b0b1f", "f5af4cd64c774693af560576a6b8039d165596b1921031ca5d739bd2e7e0554b"]
 pygments = ["71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127", "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"]
+pyparsing = ["4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1", "61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"]
+pytest = ["27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6", "58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"]
 python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
 pytz = ["1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d", "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
@@ -402,3 +522,4 @@ smart-open = ["e64c2b5e62a452fa7fc4d21aecbada826ca21097bbe117841f8f4fc53dbab676"
 traitlets = ["70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44", "d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"]
 urllib3 = ["3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398", "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"]
 wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
+zipp = ["3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e", "f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.7"
 gensim = "^3.8"
 pandas = "^0.25.3"
 pyarrow = "^0.15.1"
+pytest = "^5.2"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.9"

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,27 @@
+from corpus_explorer.preprocessing import normalize_text
+
+
+def test_normalize_text_handles_excess_whitespace():
+    raw_text = 'why the long                            pause'
+    expected = 'why the long pause'
+    assert normalize_text(raw_text) == expected
+
+    raw_text = '''
+    now for something
+    different
+
+    '''
+    expected = 'now for something different'
+    assert normalize_text(raw_text) == expected
+
+
+def test_normalize_text_removes_numbers():
+    raw_text = 'ya hate 2 see it'
+    expected = 'ya hate see it'
+    assert normalize_text(raw_text) == expected
+
+
+def test_normalize_text_removes_punctuation():
+    raw_text = 'that guy: he really takes the "the" out of "psychotherapist", amirite?'
+    expected = 'that guy he really takes the the out of psychotherapist amirite'
+    assert normalize_text(raw_text) == expected


### PR DESCRIPTION
Partially addresses #7 

This implements a minimal text normalization function. We can improve it later if needed, but for now I just wanted to have an example of what goes there.

I also added unit tests for it, and took the opportunity to set up unit testing with pytest through a `make` target. No need to worry about having activated the virtualenv or anything like that, just run `make test`.