### PR TITLE
Clicking topic circle updates term ranking panel

### DIFF
--- a/corpus_explorer/app.py
+++ b/corpus_explorer/app.py
@@ -68,17 +68,6 @@ app.layout = html.Div(
             id='div-top-controls',
             children=[
                 html.Div(
-                    id='slider-topic-size-scaling-container',
-                    children=drc.NamedSlider(
-                        name='Topic Size Scaling',
-                        id='slider-topic-size-scaling',
-                        min=1,
-                        max=2,
-                        step=0.1,
-                        value=1,
-                    ),
-                ),
-                html.Div(
                     id='slider-term-relevance-lambda-container',
                     children=drc.NamedSlider(
                         name='Lambda',
@@ -115,20 +104,30 @@ app.layout = html.Div(
 )
 
 
-
 @app.callback(
-    Output('graph-topic-scatter-plot-container', 'children'),
-    [Input('slider-topic-size-scaling', 'value')])
-def update_topic_scatter_plot_marker_sizes(topic_size_scaling):
+    [Output('input-topic-id', 'value'),
+     Output('graph-topic-scatter-plot-container', 'children')],
+    [Input('graph-topic-scatter-plot', 'clickData')],
+)
+def update_topic_scatter_plot_selection(clickData):
+    # Default to 0 during app initialization
+    if clickData is None:
+        topic_id = 0
+    else:
+        topic_id = clickData['points'][0]['customdata']['topic_id']
+
     topic_scatter_plot = figs.serve_topic_scatter_plot(
-        topic_coordinates, topic_proportions, topic_size_scaling,
+        topic_coordinates, topic_proportions, topic_id,
     )
 
-    return dcc.Graph(
-        id='graph-topic-scatter-plot',
-        figure=topic_scatter_plot,
-        style={'height': '85vh', 'width': '100%'},
+    return [
+        topic_id,
+        dcc.Graph(
+            id='graph-topic-scatter-plot',
+            figure=topic_scatter_plot,
+            style={'height': '85vh', 'width': '100%'},
         )
+    ]
 
 
 @app.callback(

--- a/corpus_explorer/app.py
+++ b/corpus_explorer/app.py
@@ -96,7 +96,10 @@ app.layout = html.Div(
         html.Div(
             id='div-graphs',
             children=[
-                html.Div(id='graph-topic-scatter-plot-container'),
+                html.Div(id='graph-topic-scatter-plot-container',
+                         children=dcc.Graph(id='graph-topic-scatter-plot',
+                                            style={'height': '85vh', 'width': '100%'})
+                ),
                 html.Div(id='graph-term-relevance-bar-plot-container'),
             ],
         ),

--- a/corpus_explorer/utils/figures.py
+++ b/corpus_explorer/utils/figures.py
@@ -29,8 +29,13 @@ def serve_term_relevance_bar_plot(term_ranks, dictionary, topic_id, lam):
 
 
 def serve_topic_scatter_plot(
-    topic_coordinates, topic_proportions, topic_size_scaler,
+    topic_coordinates, topic_proportions, selected_topic,
 ):
+
+    marker = {'color': ['#80E1EA' for x in range(len(topic_proportions))]}
+    if selected_topic is not None:
+        marker['color'][selected_topic] = '#E98364'
+
     x_coords = topic_coordinates[:, 0]
     y_coords = topic_coordinates[:, 1]
 
@@ -41,8 +46,14 @@ def serve_topic_scatter_plot(
     data = go.Scatter(
         x=x_coords,
         y=y_coords,
-        mode='markers',
-        marker_size=topic_sizes * topic_size_scaler,
+        customdata=[{'topic_id': x} for x in range(len(x_coords))],
+        mode='markers+text',
+        marker_size=topic_sizes,
+        marker=marker,
+        text=[str(x) for x in range(len(x_coords))],
+        textposition='middle center',
+        textfont={'family': 'Arial, sans-serif', 'color': 'white', 'size': 21},
+
     )
     x_pad = 0.05
     y_pad = 0.05

--- a/corpus_explorer/utils/figures.py
+++ b/corpus_explorer/utils/figures.py
@@ -40,7 +40,7 @@ def serve_topic_scatter_plot(
     y_coords = topic_coordinates[:, 1]
 
     # Scale proportion values to adequate Plotly marker size values
-    scaler = MinMaxScaler(feature_range=(20, 100))
+    scaler = MinMaxScaler(feature_range=(40, 200))
     topic_sizes = scaler.fit_transform(topic_proportions.reshape(-1, 1))
 
     data = go.Scatter(
@@ -59,10 +59,14 @@ def serve_topic_scatter_plot(
     y_pad = 0.05
     layout = go.Layout(
         title='Inter-topic distance',
-        xaxis=dict(range=[min(x_coords) - x_pad, max(x_coords) + x_pad]),
-        yaxis=dict(range=[min(y_coords) - y_pad, max(y_coords) + y_pad]),
-        transition={'duration': 500},  # animate from previous plot to next
-        # plot_bgcolor="#282b38",
+        xaxis={
+            'range': [min(x_coords) - x_pad, max(x_coords) + x_pad],
+        },
+        yaxis={
+            'range': [min(y_coords) - y_pad, max(y_coords) + y_pad],
+        },
+        transition={'duration': 200},  # animate from previous plot to next
+        # plot_bgcolor="#DDDDDB",
         # paper_bgcolor="#282b38",
         # font={"color": "#a5b1cd"},
     )


### PR DESCRIPTION
Closes #31 

This PR is derived from a branch at the base of this open PR [over here](https://github.com/hugomailhot/corpus-explorer/pull/32), so I'll wait to merge the first one before merging this one.

Screenshots:

Starting here:

![image](https://user-images.githubusercontent.com/5240492/71465314-43854900-278a-11ea-8391-24bbe56b1dc9.png)

Now click on 2:

![image](https://user-images.githubusercontent.com/5240492/71465340-55ff8280-278a-11ea-9e6e-147a81a9b3d3.png)

The maker colors are updated, and so is the topic id input box in the top right, and the term ranking panel on the right displays the words for the newly selected topic.

I also scrapped the topic resizing slider, we don't need that proof-of-concept anymore.

Current suboptimal aspects:
- Clicking on a topic marker recomputes the whole graph! However the only thing that changes in the graph is the color of the markers. Ideally we'd only update that attribute of the graph. This results in a very short lag when clicking on topics, which at some later point we might want to fix.
- I didn't figure out a way yet to make it so changing the topic id input box changes the plot, i.e. making it so that inputting a new topic id is equivalent to click the corresponding topic in the scatter plot.