### PR TITLE
Download blei ap corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: clean-test download-dataset fix_imports lint test
+.PHONY: clean-test dataset-newsgroup dataset-ap fix_imports lint test
 
 clean-test: ## remove test artifacts
 	rm -fr .pytest_cache
 
-download-dataset: ## download 20-newsgroup dataset in data folder
+dataset-newsgroup: ## download 20-newsgroup dataset in data folder
 	poetry run python scripts/download_newsgroup_dataset.py
+
+dataset-ap: ## download Associated Press dataset in data folder
+	poetry run python scripts/download_associated_press_dataset.py
 
 fix_imports: ## automatically standardize import sections in the project
 	poetry run isort --jobs 4 --recursive .

--- a/scripts/download_associated_press_dataset.py
+++ b/scripts/download_associated_press_dataset.py
@@ -8,8 +8,8 @@ import pandas as pd
 
 
 url = 'http://www.cs.columbia.edu/~blei/lda-c/ap.tgz'
+print(f'Downloading dataset from {url}')
 TEMP_FILE = 'temp_file.tgz'
-
 with open(TEMP_FILE, 'wb') as f:
     f.write(requests.get(url).content)
 
@@ -34,6 +34,9 @@ df = pd.DataFrame(
     },
 )
 
-df.to_parquet('corpus_explorer/data/ap_dataset.parquet')
+output_filepath = 'corpus_explorer/data/ap_dataset.parquet'
+print(f'Saving dataset to {output_filepath}')
+df.to_parquet(output_filepath)
 
+print('Cleaning up temp file')
 os.remove(TEMP_FILE)

--- a/scripts/download_associated_press_dataset.py
+++ b/scripts/download_associated_press_dataset.py
@@ -1,0 +1,39 @@
+import os
+import re
+import requests
+import tarfile
+from datetime import datetime
+
+import pandas as pd
+
+
+url = 'http://www.cs.columbia.edu/~blei/lda-c/ap.tgz'
+TEMP_FILE = 'temp_file.tgz'
+
+with open(TEMP_FILE, 'wb') as f:
+    f.write(requests.get(url).content)
+
+raw_text = tarfile.open(TEMP_FILE).extractfile('ap/ap.txt').read().decode('utf-8')
+
+# group 1 is YYMMDD date, group 2 is the text itself
+pattern = r'<DOCNO> AP(.+?)-\d+ </DOCNO>\s+<TEXT>(.+?)</TEXT>'
+dates, texts = zip(*re.findall(pattern, raw_text, flags=re.DOTALL))
+dates = list(dates)
+
+for i, date in enumerate(dates):
+    year, month, day = 1900 + int(date[:2]), int(date[2:4]), int(date[4:6])
+    dates[i] = datetime(year, month, day)
+
+texts = [x.strip() for x in texts]
+
+df = pd.DataFrame(
+    {
+        'text': texts,
+        'timestamp': dates,
+        'tags': None,
+    },
+)
+
+df.to_parquet('corpus_explorer/data/ap_dataset.parquet')
+
+os.remove(TEMP_FILE)


### PR DESCRIPTION
Closes #35 

I was looking for a cleaner dataset, and found out that the one used in the LDAvis demo (free subset of an Associated Press dataset) is distributed by David Blei himself.

Great news! The document IDs they use in that dataset encode the date that the articles were published, so I was able to parse them and get properly time-tagged documents.

I changed the make targets to a more generalizable `dataset-<dataset_name>`, and added `make dataset-ap`.

This will let us see if our term rankings and intertopic distances are similar to the LDAvis demo itself.