### PR TITLE
Compute topic word frequencies

### DIFF
--- a/corpus_explorer/app.py
+++ b/corpus_explorer/app.py
@@ -8,7 +8,8 @@ import dash_core_components as dcc
 import dash_html_components as html
 import numpy as np
 import pandas as pd
-from dash.dependencies import Input, Output
+from dash.dependencies import Input
+from dash.dependencies import Output
 from gensim.matutils import corpus2csc
 from gensim.models import LdaModel
 
@@ -129,7 +130,7 @@ def update_topic_scatter_plot_selection(clickData):
             id='graph-topic-scatter-plot',
             figure=topic_scatter_plot,
             style={'height': '85vh', 'width': '100%'},
-        )
+        ),
     ]
 
 

--- a/corpus_explorer/app.py
+++ b/corpus_explorer/app.py
@@ -151,9 +151,9 @@ def update_term_relevance_bar_plot(lambda_value, topic_id):
     return dcc.Graph(
         id='graph-term-relevance-bar-plot',
         figure=term_relevance_bar_plot,
-        style={'height': '85vh', 'widht': '100%'},
+        style={'height': '85vh', 'width': '100%'},
     )
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server(debug=False)

--- a/corpus_explorer/utils/nlp.py
+++ b/corpus_explorer/utils/nlp.py
@@ -14,7 +14,6 @@ from gensim.matutils import corpus2csc
 from scipy.spatial.distance import jensenshannon
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
-from sklearn.preprocessing import MinMaxScaler
 
 
 # Reasonable range for object sizes in Plotly
@@ -23,41 +22,6 @@ MAX_MARKER_SIZE = 100
 
 # Regex for punctuation in English text
 PUNCT_RE = r'[!"#$%&\'()*+,./:;<=>?@\^_`{|}~]'
-
-
-def normalize_text(text: str) -> str:
-    """Take raw text and apply several normalization steps to it.
-
-    Specifically we perform:
-        - lowercasing
-        - numbers removal
-        - punctuation removal
-
-    Notes
-    -----
-    This function is currently just a minimal example. We might want to consider
-    other normalization steps, such as:
-        - stopword removal
-        - lemmatization
-        - stemming
-
-    Parameters
-    ----------
-    text:
-        Input text in its raw form.
-
-    Returns
-    -------
-    Normalized text.
-
-    """
-    text = text.lower()
-    text = re.sub(r'\d+', '', text)
-    text = re.sub(PUNCT_RE, '', text)
-    text = re.sub(r'\s\s+', ' ', text)  # Handle excess whitespace
-    text = text.strip()  # No whitespace at start and end of string
-
-    return text
 
 
 def get_docterm_matrix(corpus: Iterable[str]) -> List[Tuple[int]]:
@@ -235,3 +199,38 @@ def get_topic_term_ranks(
             term_ranks[lam][topic_id] = ranked_term_ids
 
     return term_ranks
+
+
+def normalize_text(text: str) -> str:
+    """Take raw text and apply several normalization steps to it.
+
+    Specifically we perform:
+        - lowercasing
+        - numbers removal
+        - punctuation removal
+
+    Notes
+    -----
+    This function is currently just a minimal example. We might want to consider
+    other normalization steps, such as:
+        - stopword removal
+        - lemmatization
+        - stemming
+
+    Parameters
+    ----------
+    text:
+        Input text in its raw form.
+
+    Returns
+    -------
+    Normalized text.
+
+    """
+    text = text.lower()
+    text = re.sub(r'\d+', '', text)
+    text = re.sub(PUNCT_RE, '', text)
+    text = re.sub(r'\s\s+', ' ', text)  # Handle excess whitespace
+    text = text.strip()  # No whitespace at start and end of string
+
+    return text

--- a/corpus_explorer/utils/nlp.py
+++ b/corpus_explorer/utils/nlp.py
@@ -68,6 +68,44 @@ def get_docterm_matrix(corpus: Iterable[str]) -> List[Tuple[int]]:
     return docterm, dictionary
 
 
+def get_term_frequencies(docterm, termtopics, topic_proportions, doclength):
+    """Compute overall term frequencies and estimated per-topic term frequencies.
+
+    Parameters
+    ----------
+    docterm:
+        asdf
+    termtopics:
+        asdf
+
+    Returns
+    -------
+    Dict containing term frequencies for 'all' topics and for each topic id.
+
+    """
+    term_frequencies = {'all': defaultdict(int)}
+
+    # Compute overall term frequencies
+    for doc in docterm:
+        for term_id, count in doc:
+            term_frequencies['all'][term_id] += count
+
+    # Estimate per-topic term frequencies
+    n_terms = sum(doclength)
+    for topic_id in range(termtopics.shape[0]):
+        term_frequencies[topic_id] = {}
+        for term_id in range(termtopics.shape[1]):
+            # < 1% of the time, the estimate is larger than the total count.
+            # We take the min to ensure per-topic frequency doesn't exceed
+            # total frequency.
+            term_frequencies[topic_id][term_id] = min(
+                n_terms * topic_proportions[topic_id] * termtopics[topic_id][term_id],
+                term_frequencies['all'][term_id],
+            )
+
+    return term_frequencies
+
+
 def get_topic_coordinates(topicterms, method='pca'):
     """Compute a 2-dimensional embeddings of topics that reflects their
     distance from one another.

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,9 +386,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "4.3.21"
 
-[package.dependencies]
-toml = "*"
-
 [[package]]
 category = "main"
 description = "Various helpers to pass data to untrusted environments and back."
@@ -547,6 +544,17 @@ ipython-genutils = "*"
 jsonschema = ">=2.4,<2.5.0 || >2.5.0"
 jupyter-core = "*"
 traitlets = ">=4.1"
+
+[[package]]
+category = "main"
+description = "Natural Language Toolkit"
+name = "nltk"
+optional = false
+python-versions = "*"
+version = "3.4.5"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 category = "main"
@@ -914,6 +922,14 @@ requests = "*"
 
 [[package]]
 category = "main"
+description = "Get list of common stop words in various languages in Python"
+name = "stop-words"
+optional = false
+python-versions = "*"
+version = "2018.7.23"
+
+[[package]]
+category = "main"
 description = "Terminals served to xterm.js using Tornado websockets"
 name = "terminado"
 optional = false
@@ -940,15 +956,6 @@ name = "testpath"
 optional = false
 python-versions = "*"
 version = "0.4.4"
-
-[[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
-marker = "extra == \"pyproject\""
-name = "toml"
-optional = false
-python-versions = "*"
-version = "0.10.0"
 
 [[package]]
 category = "main"
@@ -1027,7 +1034,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "8e85dfd462824483de5083539fd5bffda6b2619672bff7ee07299a517417c263"
+content-hash = "2a9a3ca68beb3955308c9aaa9dbb0c34f71b93e2744056216619c09131a531d5"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -1081,6 +1088,7 @@ mistune = ["59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e", "
 more-itertools = ["b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d", "c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"]
 nbconvert = ["21fb48e700b43e82ba0e3142421a659d7739b65568cc832a13976a77be16b523", "f0d6ec03875f96df45aa13e21fd9b8450c42d7e1830418cccc008c0df725fcee"]
 nbformat = ["b9a0dbdbd45bb034f4f8893cafd6f652ea08c8c1674ba83f2dc55d3955743b0b", "f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402"]
+nltk = ["a08bdb4b8a1c13de16743068d9eb61c8c71c2e5d642e8e08205c528035843f82", "bed45551259aa2101381bbdd5df37d44ca2669c5c3dad72439fa459b29137d94"]
 notebook = ["399a4411e171170173344761e7fd4491a3625659881f76ce47c50231ed714d9b", "f67d76a68b1074a91693e95dea903ea01fd02be7c9fac5a4b870b8475caed805"]
 numpy = ["0a7a1dd123aecc9f0076934288ceed7fd9a81ba3919f11a855a7887cbe82a02f", "0c0763787133dfeec19904c22c7e358b231c87ba3206b211652f8cbe1241deb6", "3d52298d0be333583739f1aec9026f3b09fdfe3ddf7c7028cb16d9d2af1cca7e", "43bb4b70585f1c2d153e45323a886839f98af8bfa810f7014b20be714c37c447", "475963c5b9e116c38ad7347e154e5651d05a2286d86455671f5b1eebba5feb76", "64874913367f18eb3013b16123c9fed113962e75d809fca5b78ebfbb73ed93ba", "683828e50c339fc9e68720396f2de14253992c495fdddef77a1e17de55f1decc", "6ca4000c4a6f95a78c33c7dadbb9495c10880be9c89316aa536eac359ab820ae", "75fd817b7061f6378e4659dd792c84c0b60533e867f83e0d1e52d5d8e53df88c", "7d81d784bdbed30137aca242ab307f3e65c8d93f4c7b7d8f322110b2e90177f9", "8d0af8d3664f142414fd5b15cabfd3b6cc3ef242a3c7a7493257025be5a6955f", "9679831005fb16c6df3dd35d17aa31dc0d4d7573d84f0b44cc481490a65c7725", "a8f67ebfae9f575d85fa859b54d3bdecaeece74e3274b0b5c5f804d7ca789fe1", "acbf5c52db4adb366c064d0b7c7899e3e778d89db585feadd23b06b587d64761", "ada4805ed51f5bcaa3a06d3dd94939351869c095e30a2b54264f5a5004b52170", "c7354e8f0eca5c110b7e978034cd86ed98a7a5ffcf69ca97535445a595e07b8e", "e2e9d8c87120ba2c591f60e32736b82b67f72c37ba88a4c23c81b5b8fa49c018", "e467c57121fe1b78a8f68dd9255fbb3bb3f4f7547c6b9e109f31d14569f490c3", "ede47b98de79565fcd7f2decb475e2dcc85ee4097743e551fe26cfc7eb3ff143", "f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316", "fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5"]
 packaging = ["28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47", "d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"]
@@ -1115,10 +1123,10 @@ scipy = ["0b8c9dc042b9a47912b18b036b4844029384a5b8d89b64a4901ac3e06876e5f6", "18
 send2trash = ["60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2", "f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"]
 six = ["1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd", "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"]
 smart-open = ["e64c2b5e62a452fa7fc4d21aecbada826ca21097bbe117841f8f4fc53dbab676"]
+stop-words = ["6df3ad5f5de697daa437e4445c86c73604e6bc138dd0dc0fac55664aa4e6b03e"]
 terminado = ["4804a774f802306a7d9af7322193c5390f1da0abb429e082a10ef1d46e6fb2c2", "a43dcb3e353bc680dd0783b1d9c3fc28d529f190bc54ba9a229f72fe6e7a54d7"]
 testfixtures = ["8f22100d4fb841b958f64e71c8820a32dc46f57d4d7e077777b932acd87b7327", "9334f64d4210b734d04abff516d6ddaab7328306a0c4c1268ce4624df51c4f6d"]
 testpath = ["60e0a3261c149755f4399a1fff7d37523179a70fdc3abdf78de9fc2604aeec7e", "bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"]
-toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]
 tornado = ["349884248c36801afa19e342a77cc4458caca694b0eda633f5878e458a44cb2c", "398e0d35e086ba38a0427c3b37f4337327231942e731edaa6e9fd1865bbd6f60", "4e73ef678b1a859f0cb29e1d895526a20ea64b5ffd510a2307b5998c7df24281", "559bce3d31484b665259f50cd94c5c28b961b09315ccd838f284687245f416e5", "abbe53a39734ef4aba061fca54e30c6b4639d3e1f59653f0da37a0003de148c7", "c845db36ba616912074c5b1ee897f8e0124df269468f25e4fe21fe72f6edd7a9", "c9399267c926a4e7c418baa5cbe91c7d1cf362d505a1ef898fde44a07c9dd8a5"]
 traitlets = ["70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44", "d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"]
 urllib3 = ["a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293", "f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ ipywidgets = "^7.5"
 numpy = "^1.17"
 scipy = "^1.3"
 dash = "^1.7"
+nltk = "^3.4"
+stop-words = "^2018.7"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.9"


### PR DESCRIPTION
# Guess who's back

Finally got back to this.

Per-topic word frequencies are estimated by using the following formula:

```
freq(term|topic) ~= n_total_tokens * topic_probability * term_probability_given_topic
```

It sometimes overshoots (about 0.13% of the time in a test I ran against the Associated Press corpus), so I take the min between a term's total frequency and the estimated one.

The term relevance plot on the right side is updated to display both total and per-topic counts, copying what's done in LDAviz.

### Other additions
- stopword removal: I was tired of seeing the word "said" with max frequency, even when using a pre-made list of stopwords, so I added a few of my own
- proper tokenizer: using NLTK's word tokenizer, which will be downloaded first if not found on the user's computer

### To run this code

```bash
$ poetry update
$ poetry run python corpus_explorer/app.py corpus_explorer/data/ap_dataset.parquet 40
```