### PR TITLE
Topic proportions time series plot

### DIFF
--- a/corpus_explorer/assets/custom-styles.css
+++ b/corpus_explorer/assets/custom-styles.css
@@ -25,7 +25,7 @@
     align-items: stretch;
 }
 
-#graph-topic-scatter-plot-container {
+#topic-comparison {
     flex: 1 66%;
 }
 

--- a/corpus_explorer/utils/figures.py
+++ b/corpus_explorer/utils/figures.py
@@ -91,8 +91,12 @@ def serve_topic_scatter_plot(
 
 
 def serve_topic_volume_over_time_plot(
-    volume_over_time_df,
+    volume_over_time_df, selected_topic,
 ):
+
+    # marker = {'fillcolor': ["rgba(25, 25, 25, 0.5)" for x in range(volume_over_time_df.shape[1])]}
+    # if selected_topic is not None:
+    #     marker['opacity'][selected_topic] = 1
 
     data = []
     for topic_id in volume_over_time_df.columns:
@@ -100,8 +104,19 @@ def serve_topic_volume_over_time_plot(
             go.Scatter(
                 x=volume_over_time_df.index,
                 y=volume_over_time_df[topic_id],
+                customdata=[
+                    {'topic_id': topic_id}
+                    for x in range(volume_over_time_df.shape[0])
+                ],
+                hoveron='fills+points',
+                # marker=marker,
                 mode='lines',
                 stackgroup='A',
+                fillcolor=(
+                    'rgba(50, 50, 50, 1)'
+                    if topic_id == selected_topic
+                    else 'rgba(50, 50, 50, 0.2)'
+                )
             )
         )
 

--- a/corpus_explorer/utils/figures.py
+++ b/corpus_explorer/utils/figures.py
@@ -88,3 +88,24 @@ def serve_topic_scatter_plot(
     figure = go.Figure(data=data, layout=layout)
 
     return figure
+
+
+def serve_topic_volume_over_time_plot(
+    volume_over_time_df,
+):
+
+    data = []
+    for topic_id in volume_over_time_df.columns:
+        data.append(
+            go.Scatter(
+                x=volume_over_time_df.index,
+                y=volume_over_time_df[topic_id],
+                mode='lines',
+                stackgroup='A',
+            )
+        )
+
+    figure = go.Figure(data=data)
+
+    return figure
+


### PR DESCRIPTION
Let's merge this before we start getting diverging branches.

Things I'd like to improve about this:
- Can't click in the stacked area in the time series plot: have to click on one of the points in the line at the top of a stacked area
- The highlighting is very ugly
- The current time series defaults to monthly topic proportion computation. Introducing and interface to allow flexible time granularity would be a big win. Maybe that interface could be controlled from the dashboard itself.